### PR TITLE
Bug Fix: pip install from git

### DIFF
--- a/build_deployment.sh
+++ b/build_deployment.sh
@@ -17,7 +17,7 @@ fi
 TARGET_ENV=${TARGET}_deuce_deployment
 PIP_REQUIRES=${TARGET}/requirements.txt
 
-INI_SPACE=${TARGET_ENV}/src/master/ini
+INI_SPACE=${TARGET_ENV}/src/deuce-master/ini
 
 if [ -n "${PYTHON_BINARY}" ]; then
 	${PYTHON_BINARY} -c "import sys

--- a/gunicorn/requirements.txt
+++ b/gunicorn/requirements.txt
@@ -1,2 +1,2 @@
 gunicorn
--e git://github.com/rackerlabs/deuce#egg=master
+-e git://github.com/rackerlabs/deuce#egg=deuce_master

--- a/uwsgi/requirements.txt
+++ b/uwsgi/requirements.txt
@@ -1,2 +1,2 @@
 uWSGI
--e git://github.com/rackerlabs/deuce#egg=master
+-e git://github.com/rackerlabs/deuce#egg=deuce_master


### PR DESCRIPTION
- We need to be careful of the "egg" name used in the pip+git installs to ensure they don't overwrite each other.
